### PR TITLE
fix: rename TEA_PREFIX to TEA_DIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     paths:
       - deno.json

--- a/src/hooks/useConfig.test.ts
+++ b/src/hooks/useConfig.test.ts
@@ -25,12 +25,12 @@ Deno.test("useConfig", () => {
   assert(_internals.initialized())
 })
 
-Deno.test("useConfig empty TEA_PREFIX is ignored", () => {
-  assertEquals(ConfigDefault({ TEA_PREFIX: "" }).prefix, Path.home().join(".tea"))
-  assertEquals(ConfigDefault({ TEA_PREFIX: "   " }).prefix, Path.home().join(".tea"))
-  assertEquals(ConfigDefault({ TEA_PREFIX: " /  " }).prefix, Path.root)
-  assertThrows(() => ConfigDefault({ TEA_PREFIX: " foo  " }))
-  assertThrows(() => ConfigDefault({ TEA_PREFIX: "foo" }))
+Deno.test("useConfig empty TEA_DIR is ignored", () => {
+  assertEquals(ConfigDefault({ TEA_DIR: "" }).prefix, Path.home().join(".tea"))
+  assertEquals(ConfigDefault({ TEA_DIR: "   " }).prefix, Path.home().join(".tea"))
+  assertEquals(ConfigDefault({ TEA_DIR: " /  " }).prefix, Path.root)
+  assertThrows(() => ConfigDefault({ TEA_DIR: " foo  " }))
+  assertThrows(() => ConfigDefault({ TEA_DIR: "foo" }))
 })
 
 Deno.test("useConfig empty TEA_PANTRY_PATH is ignored", () => {

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -18,7 +18,8 @@ export interface Config {
 }
 
 export function ConfigDefault(env = Deno.env.toObject()): Config {
-  const prefix = flatmap(env['TEA_PREFIX']?.trim(), x => new Path(x)) ?? Path.home().join('.tea')
+  // FIXME: temporarily respect TEA_PREFIX for backwards compat (also required by CI using v0 CLI)
+  const prefix = flatmap(env['TEA_PREFIX']?.trim() ?? env['TEA_DIR']?.trim(), x => new Path(x)) ?? Path.home().join('.tea')
   const pantries = env['TEA_PANTRY_PATH']?.split(":").compact(x => flatmap(x.trim(), x => Path.abs(x) ?? Path.cwd().join(x))) ?? []
   const cache = Path.abs(env['TEA_CACHE_DIR']) ?? prefix.join('tea.xyz/var/www')
   const isCI = boolize(env['CI']) ?? false

--- a/src/hooks/usePantry.test.ts
+++ b/src/hooks/usePantry.test.ts
@@ -30,7 +30,10 @@ Deno.test("available()", async () => {
 })
 
 Deno.test("runtime.env", async () => {
-  const TEA_PANTRY_PATH = new Path(Deno.env.get("SRCROOT")!).join("fixtures").string
+  const url = new URL(import.meta.url)
+  let srcroot = new Path(url.pathname).parent().parent().parent()
+  if (!srcroot.join("fixtures").exists()) srcroot = srcroot.parent().parent() // running from dnt
+  const TEA_PANTRY_PATH = srcroot.join("fixtures").string
   const { prefix } = useTestConfig({ TEA_PANTRY_PATH  })
 
   const deps = [{

--- a/src/hooks/useShellEnv.ts
+++ b/src/hooks/useShellEnv.ts
@@ -15,7 +15,7 @@ export const EnvKeys = [
   'DYLD_FALLBACK_LIBRARY_PATH',
   'SSL_CERT_FILE',
   'LDFLAGS',
-  'TEA_PREFIX',
+  'TEA_DIR',
   'ACLOCAL_PATH'
 ] as const
 export type EnvKey = typeof EnvKeys[number]
@@ -134,7 +134,7 @@ function suffixes(key: EnvKey) {
     case 'CMAKE_PREFIX_PATH':
     case 'SSL_CERT_FILE':
     case 'LDFLAGS':
-    case 'TEA_PREFIX':
+    case 'TEA_DIR':
     case 'ACLOCAL_PATH':
       return []  // we handle these specially
     default: {

--- a/src/hooks/useSync.test.ts
+++ b/src/hooks/useSync.test.ts
@@ -5,15 +5,15 @@ import useSync from "./useSync.ts"
 
 Deno.test("useSync", async runner => {
   await runner.step("w/o git", async () => {
-    const TEA_PREFIX = Deno.makeTempDirSync()
-    const conf = useTestConfig({ TEA_PREFIX, TEA_PANTRY_PATH: `${TEA_PREFIX}/tea.xyz/var/pantry` })
+    const TEA_DIR = Deno.makeTempDirSync()
+    const conf = useTestConfig({ TEA_DIR, TEA_PANTRY_PATH: `${TEA_DIR}/tea.xyz/var/pantry` })
     assert(conf.git === undefined)
     await test()
   })
 
   await runner.step("w/git", async () => {
-    const TEA_PREFIX = Deno.makeTempDirSync()
-    const conf = useTestConfig({ TEA_PREFIX, TEA_PANTRY_PATH: `${TEA_PREFIX}/tea.xyz/var/pantry`, PATH: "/usr/bin" })
+    const TEA_DIR = Deno.makeTempDirSync()
+    const conf = useTestConfig({ TEA_DIR, TEA_PANTRY_PATH: `${TEA_DIR}/tea.xyz/var/pantry`, PATH: "/usr/bin" })
     assert(conf.git !== undefined)
     await test()
 

--- a/src/hooks/useTestConfig.ts
+++ b/src/hooks/useTestConfig.ts
@@ -5,11 +5,12 @@ export function useTestConfig(env?: Record<string, string>) {
   env ??= {}
 
   /// always prefer a new prefix
-  env.TEA_PREFIX ??= Path.mktemp().string
+  env.TEA_DIR ??= Path.mktemp().string
 
   /// reuse these unless the test overrides them to speed up testing
-  env.TEA_CACHE_DIR ??= Path.home().join(".tea/tea.xyz/var/www").string
-  env.TEA_PANTRY_PATH ??= Path.home().join(".tea/tea.xyz/var/pantry").string
+  const config = ConfigDefault()
+  env.TEA_CACHE_DIR ??= config.cache.string
+  env.TEA_PANTRY_PATH ??= config.prefix.join("tea.xyz/var/pantry").string
 
   return useConfig(ConfigDefault(env))
 }

--- a/src/plumbing/resolve.test.ts
+++ b/src/plumbing/resolve.test.ts
@@ -11,7 +11,7 @@ import SemVer from "../utils/semver.ts"
 import Path from "../utils/Path.ts"
 
 Deno.test("resolve cellar.has", {
-  permissions: {'read': true, 'env': ["TMPDIR", "TMP", "TEMP", "HOME"], 'write': [Deno.env.get("TMPDIR") || Deno.env.get("TMP") || Deno.env.get("TEMP") || "/tmp"] }
+  permissions: {'read': true, 'env': true, 'write': [Deno.env.get("TMPDIR") || Deno.env.get("TMP") || Deno.env.get("TEMP") || "/tmp"] }
 }, async runner => {
   const prefix = useTestConfig().prefix
   const pkg = { project: "foo", version: new SemVer("1.0.0") }
@@ -118,7 +118,7 @@ Deno.test("resolve cellar.has", {
   })
 })
 
-const permissions = { net: false, read: true, env: ["TMPDIR", "HOME", "TMP", "TEMP"], write: true /*FIXME*/ }
+const permissions = { net: false, read: true, env: true, write: true /*FIXME*/ }
 
 // https://github.com/teaxyz/cli/issues/655
 Deno.test("postgres@500 fails", { permissions }, async () => {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -78,7 +78,7 @@ export function flatmap<S, T>(t: Promise<T | Falsy> | (T | Falsy), body: (t: T) 
           .then(body => body || undefined)
           .catch(err => { if (!opts?.rescue) throw err; else return undefined } )
         return bar
-      })
+      }).catch(err => { if (!opts?.rescue) throw err; else return undefined } )
       return foo
     } else {
       if (t) return body(t) as (S | Falsy) || undefined


### PR DESCRIPTION
Renames `TEA_PREFIX` -> `TEA_DIR`

The v1 cli warns about this change:

```console
$ tea --prefix
deprecated: TEA_PREFIX has been renamed TEA_DIR, migrate before v1.0.0+gold
```

But lib continues to install to `TEA_PREFIX`. Also

- Fixes the test failure seen in #41
- Run tests on `main` to help catch those failures sooner
- Run tests in parallel, reducing the runtime from 60s -> 40s (on my machine)
