### PR TITLE
use recursive remove on symlink cleanup

### DIFF
--- a/src/plumbing/link.ts
+++ b/src/plumbing/link.ts
@@ -60,7 +60,7 @@ export default async function link(pkg: Package | Installation) {
 
       await Deno.symlink(
         installation.path.basename(),  // makes it relative
-        shelf.join(symname).rm().string,
+        shelf.join(symname).rm({ recursive: true }).string,
         {type: 'dir'})
       } catch (err) {
         if (err instanceof Deno.errors.AlreadyExists || err.code === 'EEXIST') {


### PR DESCRIPTION
if we have a v{{major}} dir, this all fails.

https://github.com/pkgxdev/pantry/actions/runs/6372765669/job/17296651631
