### PR TITLE
Fix sync never ending when pantry is not updated in 24 hours

### DIFF
--- a/src/hooks/usePantry.ts
+++ b/src/hooks/usePantry.ts
@@ -261,10 +261,11 @@ export default function usePantry() {
   }
 
   const neglected = () => {
-    if (!prefix.exists()) return true
-    const stat = Deno.statSync(prefix.string)
-    if (!stat.mtime) return true
-    return (Date.now() - stat.mtime.getTime()) > 24 * 60 * 60 * 1000
+    const last_sync_file = prefix.join(".last_sync")
+    if (!last_sync_file.exists()) return true
+    const last_sync_date = new Date(Deno.readTextFileSync(last_sync_file.string).trim());
+    if (!last_sync_date) return true
+    return (Date.now() - last_sync_date.getTime()) > 24 * 60 * 60 * 1000
   }
 
   return {

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -79,6 +79,10 @@ async function sync(pantry_dir: Path) {
     proc.close()
 
   }
+  // Write a file indicating last sync time
+  const now = new Date().toISOString()
+  const last_sync_file = pantry_dir.join("projects").join(".last_sync")
+  await Deno.writeTextFile(last_sync_file.string, now)
 }
 
 //////////////////////// utils


### PR DESCRIPTION
**To be clear, pkgx is completely broken by now because of this issue.**

It turns out that the function that detects whether the sync was last synced recently isn't working properly, because it's relying on the mtime of the pantry/projects folder, which is set to its original mtime when downloaded by either git or tar.

This means the function would always detect outdated sync if there was no commit in the pantry repo in the last 24 hours.

This was just a quick way around it. Other solutions I tried:

1. ctime (change time). This would work better, but [Deno doesn't support it](https://github.com/denoland/deno/issues/24453). (node does)

2. tar's --touch to reset modification time, but it only works for files not for directories. Also, the pantry could have been downloaded with git.

PS: tests are failing but the code is working, and I'm using it in my fork. I will not bother fixing tests as apparently no one is merging code here anyway.