### PR TITLE
fix(path): read multi yaml file separated with ---

### DIFF
--- a/fixtures/pathtests/readYAMLAll.yaml
+++ b/fixtures/pathtests/readYAMLAll.yaml
@@ -1,0 +1,3 @@
+abc: xyz
+---
+ijk: lmn

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -11,11 +11,11 @@ export { outdent }
 import * as crypto from "jsr:@std/crypto@1"
 import { moveSync } from "jsr:@std/fs@1"
 import { writeAll } from "jsr:@std/io@^0.225.0"
-import { parse as parseYaml } from "jsr:@std/yaml@1"
+import { parse as parseYaml, parseAll as parseYamlALL } from "jsr:@std/yaml@1"
 import { SEPARATOR as SEP, fromFileUrl } from "jsr:@std/path@1"
 
 const streams = { writeAll }
 const fs = { moveSync }
-const deno = { crypto, fs, streams, parseYaml, SEP, fromFileUrl }
+const deno = { crypto, fs, streams, parseYaml, parseYamlALL, SEP, fromFileUrl }
 
 export { deno }

--- a/src/utils/Path.test.ts
+++ b/src/utils/Path.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert"
+import { assert, assertEquals, assertFalse, assertThrows, fail } from "@std/assert"
 import { SEPARATOR as SEP } from "jsr:@std/path@1"
 import Path from "./Path.ts"
 
@@ -198,6 +198,42 @@ Deno.test("Path.prettyLocalString()", () => {
   const root = Deno.build.os == 'windows' ? 'C:\\' : '/'
   assertEquals(new Path("/a/b").prettyLocalString(), `${root}a${SEP}b`)
 })
+
+Deno.test("Path.readYAMLAll()", async () => {
+  const path = Path.cwd().join("./fixtures/pathtests/readYAMLAll.yaml");
+
+  try {
+    const yamlData = await path.readYAMLAll(); // ✅ Use await
+
+    assertEquals(Array.isArray(yamlData), true, "Expected yamlData to be an array");
+
+    if (!Array.isArray(yamlData)) {
+      fail("Expected an array");
+      return;
+    }
+
+    assertEquals(yamlData.length, 2, "Expected exactly 2 YAML documents");
+    assertEquals(yamlData, [{ abc: "xyz" }, { ijk: "lmn" }], "YAML content mismatch");
+
+  } catch (err) {
+    console.error("Error reading YAML:", err);
+    fail("Error reading YAML");
+  }
+});
+
+Deno.test("Path.readYAMLAllErr()", async () => {
+  const path = Path.cwd().join("./fixtures/pathtests/invalid.yaml");
+  try {
+    await path.readYAMLAll();
+    fail("invalid file should not reach here")
+  } catch (err) {
+    if (err instanceof Error) {
+      assertEquals(err.name, "NotFound")
+    } else{
+      throw err;
+    }
+  }
+});
 
 Deno.test("Path.chuzzle()", () => {
   const path = Path.mktemp().join("file.txt").touch()

--- a/src/utils/Path.ts
+++ b/src/utils/Path.ts
@@ -4,7 +4,7 @@ import { mkdtempSync } from "node:fs"
 import * as sys from "node:path"
 import * as os from "node:os"
 
-const { fs, parseYaml, SEP } = deno
+const { fs, parseYaml, parseYamlALL, SEP } = deno
 
 // modeled after https://github.com/mxcl/Path.swift
 
@@ -403,6 +403,18 @@ export default class Path {
     try {
       const txt = await this.read()
       return parseYaml(txt)
+    } catch (err) {
+      if (err instanceof Error) {
+        err.cause = this.string
+      }
+      throw err
+    }
+  }
+
+  async readYAMLAll(): Promise<unknown> {
+    try {
+      const txt = await this.read()
+      return parseYamlALL(txt)
     } catch (err) {
       if (err instanceof Error) {
         err.cause = this.string


### PR DESCRIPTION
Currently pkgxdev is failing to autodetect skaffold when skaffold.yaml is having multiple documents with following error:
```
╰─ z skaf                                                                                                            ─╯
-deno.land -deno^2 -nodejs.org
error: Uncaught (in promise) SyntaxError: Found more than 1 document in the stream: expected a single document
    throw new SyntaxError(
          ^
    at parse (https://jsr.io/@std/yaml/1.0.5/parse.ts:87:11)
    at Path.readYAML (https://raw.githubusercontent.com/pkgxdev/libpkgx/refs/tags/v0.20.1/src/utils/Path.ts:405:14)
    at eventLoopTick (ext:core/01_core.js:177:7)
    at async skaffold_yaml (file:///Users/vkumbhar94/.pkgx/pkgx.sh/dev/v1.5.0/share/pkgx/dev/src/sniff.ts:263:18)
    at async default (file:///Users/vkumbhar94/.pkgx/pkgx.sh/dev/v1.5.0/share/pkgx/dev/src/sniff.ts:61:11)
    at async default (file:///Users/vkumbhar94/.pkgx/pkgx.sh/dev/v1.5.0/share/pkgx/dev/src/dump.ts:6:17)
    at async file:///Users/vkumbhar94/.pkgx/pkgx.sh/dev/v1.5.0/share/pkgx/dev/app.ts:48:7
Caused by: "skaffold-modules/skaffold.yaml"
```

Once this util function is available to read multi-yaml file, I will raise PR to pkgx.

issue ticket: https://github.com/pkgxdev/libpkgx/issues/82